### PR TITLE
Fix namespaced tasks and show descriptions

### DIFF
--- a/_task
+++ b/_task
@@ -5,7 +5,8 @@ function __list() {
     local -a scripts
 
     if [ -f Taskfile.yml ]; then
-        scripts=($(task -l | sed '1d' | sed 's/://' | awk '{ print $2 }'))
+        tasks=$(task -l | sed -En "s/^\* ([^[:space:]]+):[[:space:]]+(.+)$/\1 \2/p" | awk '{gsub(/:/,"\\:",$1)} 1' | awk "{ st = index(\$0,\" \"); print \$1 \":\" substr(\$0,st+1)}")
+        scripts=("${(@f)$(echo $tasks)}")
         _describe 'script' scripts
     fi
 }


### PR DESCRIPTION
This fixes the issue where namespaced tasks were not shown correctly, also it adds the feature to show task descriptions.

I tested it out with this taskfile:
```
version: '3'

tasks:
  nice:greet:
    desc: 'Description with colon: Greets the user nicely'
    cmds:
      - echo 'Hello dear user'

  greet:
    desc: Greets the user.
    cmds:
      - echo 'Hi user'
```

Output:
```
$ task
greet       -- Greets the user.
nice:greet  -- Description with colon: Greets the user nicely
```