### PR TITLE
Detect Taskfiles with suffixes

### DIFF
--- a/_task
+++ b/_task
@@ -4,7 +4,7 @@
 function __list() {
     local -a scripts
 
-    if [ -f Taskfile.yml ]; then
+    if compgen -G Taskfile*.yaml > /dev/null; then
         tasks=$(task -l | sed -En "s/^\* ([^[:space:]]+):[[:space:]]+(.+)$/\1 \2/p" | awk '{gsub(/:/,"\\:",$1)} 1' | awk "{ st = index(\$0,\" \"); print \$1 \":\" substr(\$0,st+1)}")
         scripts=("${(@f)$(echo $tasks)}")
         _describe 'script' scripts


### PR DESCRIPTION
Taskfiles that have suffixes like Taskfile.dev.yaml are automatically detected by `task` and may be used without a Taskfile.yaml present. The change looks for any Taskfile in the current directory for auto completion.